### PR TITLE
fix: moved translate to a function

### DIFF
--- a/packages/lib/src/Base.svelte
+++ b/packages/lib/src/Base.svelte
@@ -13,8 +13,6 @@
 
   const translator = initTransaltor(lang || htmlLang || 'en')
 
-  console.log('lang', lang, htmlLang)
-
   let sesamyDesignTokens = `
     * {
       --s-main-color: var(--sesamy-main-color, #E71104);

--- a/packages/lib/src/Base.svelte
+++ b/packages/lib/src/Base.svelte
@@ -2,25 +2,18 @@
   // @ts-ignore
   import libstyles from './app.css?inline';
   import { getApi } from './api';
-  import cs from './locales/cs/default.json';
-  import en from './locales/en/default.json';
-  import fi from './locales/fi/default.json';
-  import it from './locales/it/default.json';
-  import nb from './locales/nb/default.json';
-  import pl from './locales/pl/default.json';
-  import sv from './locales/sv/default.json';
+  import initTransaltor from './i18n';
 
+  let {
+    lang
+  }: { lang?: string  } = $props();  
+  const htmlLang = document.querySelector('html')?.getAttribute('lang');
+  
   const apiPromise = getApi();
 
-  let translator = {
-    cs,
-    en,
-    fi,
-    it,
-    nb,
-    pl,
-    sv
-  };
+  const translator = initTransaltor(lang || htmlLang || 'en')
+
+  console.log('lang', lang, htmlLang)
 
   let sesamyDesignTokens = `
     * {
@@ -38,17 +31,12 @@
     }
   `;
 
-  // Prio order of localization
-  // 1. explicit lang property on component
-  // 2. html-tag lang
-  // 3. english fallback
-
   let style = '<sty' + 'le>' + libstyles + sesamyDesignTokens + '</style>';
 </script>
 
 <div class="base">
   {#await apiPromise then api}
-    <slot {api} t={translator.sv}></slot>
+    <slot {api} t={translator}></slot>
   {:catch error}
     <p style="color: red">{error.message}</p>
   {/await}

--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -7,7 +7,7 @@
   import Button from "./Button.wc.svelte";
   import type { LoginProps } from "./types";
 
-  let { loading, loggedIn, userAvatar }: LoginProps = $props();
+  let { loading, loggedIn, userAvatar, t }: LoginProps & { t: { [key: string]: string } } = $props();
 
   const login = async (api: SesamyAPI) => {
     loading = true;
@@ -42,14 +42,14 @@
   };
 </script>
 
-<Base let:api>
+<Base let:api let:t>
   {#await checkLoggedIn(api) then _}
     {#if loading || loggedIn}
       <Avatar {loading} onclick={() => logout(api)} size="sm"></Avatar>
     {:else}
       <slot name="loginButton">
         <Button part="loginButton" {loading} onclick={() => login(api)}>
-          Login
+          {t('login')}
         </Button>
       </slot>
     {/if}

--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -7,7 +7,7 @@
   import Button from "./Button.wc.svelte";
   import type { LoginProps } from "./types";
 
-  let { loading, loggedIn, userAvatar, t }: LoginProps = $props();
+  let { loading, loggedIn, userAvatar}: LoginProps = $props();
 
   const login = async (api: SesamyAPI) => {
     loading = true;

--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -7,7 +7,7 @@
   import Button from "./Button.wc.svelte";
   import type { LoginProps } from "./types";
 
-  let { loading, loggedIn, userAvatar }: LoginProps = $props();
+  let { loading, loggedIn, userAvatar, t }: LoginProps = $props();
 
   const login = async (api: SesamyAPI) => {
     loading = true;

--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -7,7 +7,7 @@
   import Button from "./Button.wc.svelte";
   import type { LoginProps } from "./types";
 
-  let { loading, loggedIn, userAvatar, t }: LoginProps & { t: { [key: string]: string } } = $props();
+  let { loading, loggedIn, userAvatar }: LoginProps = $props();
 
   const login = async (api: SesamyAPI) => {
     loading = true;

--- a/packages/lib/src/Paywall.wc.svelte
+++ b/packages/lib/src/Paywall.wc.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import Base from './Base.svelte';
   import type { IconName } from './icons/types';
+  import type { Translate } from './i18n';
   import type { PaywallProps } from './types';
   import { onMount } from 'svelte';
   import PaywallRenderer from './components/PaywallRenderer.svelte';
@@ -22,7 +23,7 @@
     'settings-url': settingsUrl,
     template = 'ARTICLE',
     t
-  }: PaywallProps & { t: { [key: string]: string } } = $props();
+  }: PaywallProps & { t: Translate  } = $props();
   let paywall = $state<{ [key: string]: any } | undefined>(undefined);
 
   onMount(async () => {

--- a/packages/lib/src/components/PaywallRenderer.svelte
+++ b/packages/lib/src/components/PaywallRenderer.svelte
@@ -9,7 +9,7 @@
   import type { IconName } from './../icons/types';
   import Features from './../components/Features.svelte';
   import { twMerge } from 'tailwind-merge';
-  import type { Translate } from '../i18n';
+  import type { TranslationFunction } from '../i18n';
 
   const paymentMethods = [
     'visa',
@@ -23,7 +23,7 @@
   ] as IconName[];
 
   type Props = {
-    t: Translate;
+    t: TranslationFunction;
     horizontal?: boolean;
     paywall: { [key: string]: any }; // TODO: type define paywall props
   };

--- a/packages/lib/src/components/PaywallRenderer.svelte
+++ b/packages/lib/src/components/PaywallRenderer.svelte
@@ -9,6 +9,7 @@
   import type { IconName } from './../icons/types';
   import Features from './../components/Features.svelte';
   import { twMerge } from 'tailwind-merge';
+  import type { Translate } from '../i18n';
 
   const paymentMethods = [
     'visa',
@@ -22,7 +23,7 @@
   ] as IconName[];
 
   type Props = {
-    t: { [key: string]: string };
+    t: Translate;
     horizontal?: boolean;
     paywall: { [key: string]: any }; // TODO: type define paywall props
   };
@@ -34,7 +35,7 @@
 
 <Column class="w-full shadow-lg pt-6 bg-[var(--s-bg-color,purple)] rounded-3xl">
   <Row class="text-sm gap-1 pt-2 font-bold">
-    {t['already_subscribing']} <a href="/" class="text-[var(--s-main-color,purple)]"> Logga in </a>
+    {t('already_subscribing')} <a href="/" class="text-[var(--s-main-color,purple)]"> Logga in </a>
   </Row>
 
   <Column class={twMerge('gap-4 px-16 pb-16 pt-6 w-full', horizontal && 'px-6 pb-4')} up left>

--- a/packages/lib/src/i18n.ts
+++ b/packages/lib/src/i18n.ts
@@ -10,19 +10,19 @@ export type Key = keyof typeof en;
 type Languages = { [lang: string]: { [key in Key]: string } };
 
 const languages: Languages = {
-    cs,
-    en,
-    fi,
-    it,
-    nb,
-    pl,
-    sv
+  cs,
+  en,
+  fi,
+  it,
+  nb,
+  pl,
+  sv
 };
 
 export interface TranslationFunction {
-(key: Key): string;
+  (key: Key): string;
 }
-  
+
 export default function init(language: string): TranslationFunction {
-  return (key: Key) => languages[language][key]; 
+  return (key: Key) => languages[language][key];
 }

--- a/packages/lib/src/i18n.ts
+++ b/packages/lib/src/i18n.ts
@@ -24,5 +24,5 @@ export interface TranslationFunction {
 }
   
 export default function init(language: string): TranslationFunction {
-  return (key: Key) => languages[language][key] || languages.en[key]; 
+  return (key: Key) => languages[language][key]; 
 }

--- a/packages/lib/src/i18n.ts
+++ b/packages/lib/src/i18n.ts
@@ -1,0 +1,28 @@
+import cs from './locales/cs/default.json';
+import en from './locales/en/default.json';
+import fi from './locales/fi/default.json';
+import it from './locales/it/default.json';
+import nb from './locales/nb/default.json';
+import pl from './locales/pl/default.json';
+import sv from './locales/sv/default.json';
+
+export type Key = keyof typeof en;
+type Languages = { [lang: string]: { [key in Key]: string } };
+
+const languages: Languages = {
+    cs,
+    en,
+    fi,
+    it,
+    nb,
+    pl,
+    sv
+};
+
+export interface TranslationFunction {
+(key: Key): string;
+}
+  
+export default function init(language: string): TranslationFunction {
+  return (key: Key) => languages[language][key] || languages.en[key]; 
+}

--- a/packages/lib/src/locales/cs/default.json
+++ b/packages/lib/src/locales/cs/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Už jste se přihlásili k odběru?"
+  "already_subscribing": "Už jste se přihlásili k odběru?",
+  "login": "Přihlášení"
 }

--- a/packages/lib/src/locales/en/default.json
+++ b/packages/lib/src/locales/en/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Already subscribing?"
+  "already_subscribing": "Already subscribing?",
+  "login": "Login"
 }

--- a/packages/lib/src/locales/fi/default.json
+++ b/packages/lib/src/locales/fi/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Oletko jo tilannut?"
+  "already_subscribing": "Oletko jo tilannut?",
+  "login": "Kirjaudu sisään"
 }

--- a/packages/lib/src/locales/it/default.json
+++ b/packages/lib/src/locales/it/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Siete già abbonati?"
+  "already_subscribing": "Siete già abbonati?",
+  "login": "Accesso"
 }

--- a/packages/lib/src/locales/nb/default.json
+++ b/packages/lib/src/locales/nb/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Abonnerer du allerede?"
+  "already_subscribing": "Abonnerer du allerede?",
+  "login": "Logg inn"
 }

--- a/packages/lib/src/locales/pl/default.json
+++ b/packages/lib/src/locales/pl/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Już subskrybujesz?"
+  "already_subscribing": "Już subskrybujesz?",
+  "login": "Logowanie"
 }

--- a/packages/lib/src/locales/sv/default.json
+++ b/packages/lib/src/locales/sv/default.json
@@ -1,3 +1,4 @@
 {
-  "already_subscribing": "Prenumererar du redan?"
+  "already_subscribing": "Prenumererar du redan?",
+  "login": "Logga in"
 }

--- a/packages/lib/src/stories/Login.stories.ts
+++ b/packages/lib/src/stories/Login.stories.ts
@@ -2,10 +2,12 @@
 import { html } from "lit-html";
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { Login } from "@sesamy/sesamy-components";
+import { ifDefined } from "lit-html/directives/if-defined.js";
 
 type LoginProps = {
   buttonText?: string;
   onLogin?: (event: CustomEvent) => void;
+  lang?: string;
 };
 
 const meta: Meta<LoginProps> = {
@@ -15,12 +17,14 @@ const meta: Meta<LoginProps> = {
   render: (args) => html`
     <sesamy-login
       .buttonText=${args.buttonText}
+      .outline=${ifDefined(args.lang)}
       @login=${args.onLogin}
     ></sesamy-login>
   `,
   argTypes: {
     buttonText: { control: "text" },
     onLogin: { action: "login" },
+    lang: { control: "text" },  
   },
 };
 

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -3,6 +3,7 @@ export interface LoginProps {
   loading?: boolean;
   loggedIn?: boolean;
   userAvatar?: string;
+  lang?: string;
   onLogin?: (event: CustomEvent) => void;
 }
 


### PR DESCRIPTION
This adds a small wrapper for the handling the translations. It enforces that all language strings available in english is available in all other languages as well, which I guess should be the case if we pull from i18nexus right?