### PR TITLE
feat: prevent fouc

### DIFF
--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -27,14 +27,10 @@
         {template}
         settings-url="https://api.sesamy.dev/paywall/paywalls/kvartal/1idkV75XtXSVQAXtTp2dL"
       ></sesamy-paywall>
-
-      <sesamy-login></sesamy-login>
     </div>
 
     <article>
       <h1>Sesamy Components Demo Page</h1>
-
-      <sesamy-avatar size="md" loading></sesamy-avatar>
 
       <p>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc sed elit sollicitudin nisl

--- a/packages/lib/src/Avatar.wc.svelte
+++ b/packages/lib/src/Avatar.wc.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { twMerge } from 'tailwind-merge';
   import Base from './Base.svelte';
+  import Row from './components/Row.svelte';
 
   export let src = '';
   export let alt = 'Avatar';
@@ -13,7 +14,7 @@
 </script>
 
 <Base>
-  <div class="relative inline-block">
+  <Row class="relative inline-block">
     <button
       type="button"
       class={twMerge(
@@ -47,10 +48,10 @@
       {:else if src}
         <img {src} {alt} class="w-full h-full object-cover" />
       {:else}
-        <div class="flex items-center justify-center w-full h-full text-white">
+        <Row class="absolute top-0 left-0 w-full h-full text-white">
           {alt.charAt(0).toUpperCase()}
-        </div>
+        </Row>
       {/if}
     </button>
-  </div>
+  </Row>
 </Base>

--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -45,11 +45,13 @@
 </script>
 
 <Base let:api let:t>
-  {#await checkLoggedIn(api) then _}
+  {#await checkLoggedIn(api)}
+    <Avatar loading={true} size="sm"></Avatar>
+  {:then _}
     {#if loading || loggedIn}
       <Avatar {loading} onclick={() => logout(api)} size="sm"></Avatar>
     {:else}
-      <Button {variant} {disabled} onclick={() => login(api)}>
+      <Button {variant} {disabled} onclick={() => login(api)} size="sm">
         {t('login')}
       </Button>
     {/if}


### PR DESCRIPTION
This PR makes the page less jumpy when the Avatar <> Login button is being displayed conditionally.

If I have time I'll refactor `Login.wc.svelte` in terms of rendering completely. The way we do it now we switch between two different elements which makes it hard to have it in a fixed place with fixed sizing (each one needs to be maintained separately and have the same sizing properties).

Always rendering an area in which either the avatar or button is shown is a better solution. This would also allow us to animate the button nicely.

I'm imagining when the user clicks "Logga in" the text transitions to dissapear at the same time as the button goes from a rectangle to a circle with the spinner inside.