### PR TITLE
feat: content-container

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   ],
   "dependencies": {
     "@ape-egg/tailwind-rows-columns": "^1.0.2",
-    "@sesamy/sesamy-js": "^1.22.0",
+    "@sesamy/sesamy-js": "^1.22.9",
     "lucide-svelte": "^0.445.0"
   }
 }

--- a/packages/lib/index.ts
+++ b/packages/lib/index.ts
@@ -1,5 +1,6 @@
-export { default as Login } from "./src/Login.wc.svelte";
-export { default as Paywall } from "./src/Paywall.wc.svelte";
-export { default as RegistrationWall } from "./src/RegistrationWall.wc.svelte";
-export { default as Button } from "./src/Button.wc.svelte";
-export { default as Avatar } from "./src/Avatar.wc.svelte";
+export { default as Login } from './src/Login.wc.svelte';
+export { default as Paywall } from './src/Paywall.wc.svelte';
+export { default as RegistrationWall } from './src/RegistrationWall.wc.svelte';
+export { default as Button } from './src/Button.wc.svelte';
+export { default as Avatar } from './src/Avatar.wc.svelte';
+export { default as ContentContainer } from './src/ContentContainer.wc.svelte';

--- a/packages/lib/src/Base.svelte
+++ b/packages/lib/src/Base.svelte
@@ -5,7 +5,7 @@
   import initTransaltor from './i18n';
   import { hexToHsl, hslArrayToCSS } from './utils/color';
 
-  let { lang }: { lang?: string } = $props();
+  let { lang, applyStyles = true }: { lang?: string; applyStyles?: boolean } = $props();
   const htmlLang = document.querySelector('html')?.getAttribute('lang');
 
   const apiPromise = getApi();
@@ -24,7 +24,7 @@
     }
   `;
 
-  let style = '<sty' + 'le>' + libstyles + sesamyDesignTokens + '</style>';
+  let style = applyStyles ? '<sty' + 'le>' + libstyles + sesamyDesignTokens + '</style>' : '';
 </script>
 
 {#await apiPromise then api}

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -1,0 +1,36 @@
+<svelte:options customElement={{ tag: 'sesamy-content-container', shadow: 'open' }} />
+
+<script lang="ts">
+  import Base from './Base.svelte';
+  import type { ContentContainerProps } from './types';
+  let {
+    'item-src': itemSrc = '',
+    pass = '',
+    'lock-mode': lockMode = 'embed'
+  }: ContentContainerProps = $props();
+  function getContent() {
+    const content = $host().querySelector('div[slot="content"]');
+    switch (lockMode) {
+      case 'encode':
+        return atob(content?.innerHTML || '');
+      case 'event':
+        // TODO: Trigger event
+        return '';
+      case 'signedUrl':
+        return 'Remote content';
+      case 'embed':
+      default:
+        return content?.innerHTML || '';
+    }
+  }
+</script>
+
+<Base let:api applyStyles={false}>
+  {#await api.entitlements.hasAccess(itemSrc, pass.split(',')) then hasAccess}
+    {#if hasAccess}
+      {getContent()}
+    {:else}
+      <slot name="preview"></slot>
+    {/if}
+  {/await}
+</Base>

--- a/packages/lib/src/sesamy-components.d.ts
+++ b/packages/lib/src/sesamy-components.d.ts
@@ -1,18 +1,25 @@
 declare namespace JSX {
   interface IntrinsicElements {
-    "sesamy-avatar": {};
-    "sesamy-button": {
+    'sesamy-avatar': {};
+    'sesamy-button': {
       buttonText?: string;
       loading?: boolean;
     };
-    "sesamy-login": {
+    'sesamy-content-container': {
+      'item-src'?: string;
+      pass?: string;
+      'access-level'?: 'public' | 'logged-in' | 'entitlement';
+      'publisher-content-id'?: string;
+      'lock-mode'?: 'embed' | 'encode' | 'signedUrl' | 'event';
+    };
+    'sesamy-login': {
       buttonText?: string;
       loading?: boolean;
       loggedIn?: boolean;
     };
-    "sesamy-registration-wall": {};
-    "sesamy-paywall": {
-      "settings-url": string;
+    'sesamy-registration-wall': {};
+    'sesamy-paywall': {
+      'settings-url': string;
     };
   }
 }

--- a/packages/lib/src/stories/ContentContainer.stories.ts
+++ b/packages/lib/src/stories/ContentContainer.stories.ts
@@ -1,0 +1,55 @@
+import { html } from 'lit-html';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import type { ContentContainerProps } from '../types';
+
+const meta: Meta<ContentContainerProps> = {
+  title: 'Components/ContentContainer',
+  tags: ['autodocs'],
+  component: 'sesamy-content-container',
+  render: (args) =>
+    html`<div>
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container item-src="https://sesamy-js.sesamy.dev/article.html">
+        <div slot="preview">This is a preview of locked content</div>
+        <div slot="content">This is the locked content</div>
+      </sesamy-content-container>
+    </div>`,
+  argTypes: {}
+};
+
+export default meta;
+
+type Story = StoryObj<ContentContainerProps & { buttonText: string }>;
+
+export const Default: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  args: {},
+  render: (args) =>
+    html`<div style="color: red;">
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container item-src="https://sesamy-js.sesamy.dev/article.html">
+        <div slot="preview">This is a preview of locked content</div>
+        <div slot="content">This is the locked content</div>
+      </sesamy-content-container>
+    </div>`
+};
+
+export const EncodedContent: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  args: {},
+  render: (args) =>
+    html` <div style="color: red;">
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container
+        item-src="https://sesamy-js.sesamy.dev/article.html"
+        lock-mode="encode"
+      >
+        <div slot="preview">This is a preview of locked content</div>
+        <div slot="content">VGhpcyBpcyB0aGUgZW5jb2RlZCBsb2NrZWQgY29udGVudA==</div>
+      </sesamy-content-container>
+    </div>`
+};

--- a/packages/lib/src/stories/ContentContainer.stories.ts
+++ b/packages/lib/src/stories/ContentContainer.stories.ts
@@ -83,3 +83,33 @@ export const PublicContent: Story = {
       </sesamy-content-container>
     </div>`
 };
+
+export const ContentEvents: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  args: {},
+  render: (args) =>
+    html` <div>
+      <script>
+        window.addEventListener('sesamyUnlocked', (event) => {
+          const container = document.getElementById('event-container');
+          container.innerHTML =
+            'Event emitted with item-src: ' +
+            event.detail.itemSrc +
+            ' and publisher-content-id: ' +
+            event.detail.publisherContentId;
+        });
+      </script>
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container
+        access-level="logged-in"
+        item-src="https://example.com/article"
+        publisher-content-id="1234"
+        lock-mode="event"
+      >
+        <div slot="preview">This is visible to unauthenticated users</div>
+      </sesamy-content-container>
+      <div id="event-container"></div>
+    </div>`
+};

--- a/packages/lib/src/stories/ContentContainer.stories.ts
+++ b/packages/lib/src/stories/ContentContainer.stories.ts
@@ -42,7 +42,7 @@ export const EncodedContent: Story = {
   },
   args: {},
   render: (args) =>
-    html` <div style="color: red;">
+    html` <div>
       <sesamy-login></sesamy-login>
       <sesamy-content-container
         item-src="https://sesamy-js.sesamy.dev/article.html"
@@ -50,6 +50,36 @@ export const EncodedContent: Story = {
       >
         <div slot="preview">This is a preview of locked content</div>
         <div slot="content">VGhpcyBpcyB0aGUgZW5jb2RlZCBsb2NrZWQgY29udGVudA==</div>
+      </sesamy-content-container>
+    </div>`
+};
+
+export const AuthenticatedUsers: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  args: {},
+  render: (args) =>
+    html` <div>
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container access-level="logged-in">
+        <div slot="preview">This is visisble for unauthenticated users</div>
+        <div slot="content">This is visisble for authenticated users</div>
+      </sesamy-content-container>
+    </div>`
+};
+
+export const PublicContent: Story = {
+  parameters: {
+    layout: 'centered'
+  },
+  args: {},
+  render: (args) =>
+    html` <div>
+      <sesamy-login></sesamy-login>
+      <sesamy-content-container access-level="public">
+        <div slot="preview">This is should not be visible</div>
+        <div slot="content">This is visisble all users</div>
       </sesamy-content-container>
     </div>`
 };

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -35,6 +35,7 @@ export type ContentContainerProps = HTMLElement & {
   'item-src'?: string;
   pass?: string;
   'access-level'?: AccessLevel;
+  'access-url'?: string;
   'publisher-content-id'?: string;
   'lock-mode'?: LockMode;
 };

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -27,3 +27,14 @@ export type ButtonProps = HTMLButtonAttributes & {
   onclick?: () => void;
   href?: string;
 };
+
+export type AccessLevel = 'public' | 'logged-in' | 'entitlement';
+export type LockMode = 'embed' | 'encode' | 'signedUrl' | 'event';
+
+export type ContentContainerProps = HTMLElement & {
+  'item-src'?: string;
+  pass?: string;
+  'access-level'?: AccessLevel;
+  'publisher-content-id'?: string;
+  'lock-mode'?: LockMode;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        main: 'hsl(var(--s-primary-color))'
+        primary: 'hsl(var(--s-primary-color))'
       }
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -897,10 +897,10 @@
     lodash-es "^4.17.21"
     read-package-up "^11.0.0"
 
-"@sesamy/sesamy-js@^1.22.0":
-  version "1.22.6"
-  resolved "https://registry.yarnpkg.com/@sesamy/sesamy-js/-/sesamy-js-1.22.6.tgz#cf108acdb79c8e1d3efc8314c9981bcaa530d220"
-  integrity sha512-EefPJhLfVcWrGf8AWbhUc6S0FKfy/RWrDYuE/SUTi9C80zsQVGE84LHbT96J1KoS/UA+c/gYjAdnyPPWZcsXlQ==
+"@sesamy/sesamy-js@^1.22.9":
+  version "1.22.9"
+  resolved "https://registry.yarnpkg.com/@sesamy/sesamy-js/-/sesamy-js-1.22.9.tgz#acdbf188c40791a1de5bd47c4c7232bac2a43652"
+  integrity sha512-xOAqv9gv0SRaXZA4Cfu3vUYIbIbH2IuK2Sscxc/o3wOvQRHzcsogtkHoPcbhkqAdMJDp8HfyM2WSOWpnWjrp8g==
   dependencies:
     "@analytics/activity-utils" "^0.1.16"
     "@analytics/scroll-utils" "^0.1.22"
@@ -6136,16 +6136,7 @@ stream-combiner2@~1.1.1:
     duplexer2 "~0.1.0"
     readable-stream "^2.0.2"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6966,16 +6957,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
This is pretty much the same feature set and interface as the old content-container. The one difference is that it doesn't fall back to the sesamy-content-data or metatags to fetch the item-src and pass properties, which I guess we need to add if we want to replace the old component.