### PR TITLE
feat: refactor authentication to global store

### DIFF
--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -1,47 +1,15 @@
 <svelte:options customElement="sesamy-login" />
 
 <script lang="ts">
-  import type { SesamyAPI } from '@sesamy/sesamy-js';
   import Avatar from './Avatar.wc.svelte';
   import Base from './Base.svelte';
   import type { LoginProps } from './types';
   import Button from './components/Button.svelte';
+  import { checkLoggedIn, login, logout } from './utils/authentication';
 
-  let { loading, loggedIn, userAvatar, 'button-text': buttonText }: LoginProps = $props();
+  let { loading, loggedIn, 'button-text': buttonText }: LoginProps = $props();
 
   let disabled = $state(false);
-
-  const login = async (api: SesamyAPI) => {
-    disabled = true;
-    try {
-      await api.auth.loginWithRedirect();
-    } catch (error) {
-      disabled = false;
-      console.error('Login failed:', error);
-    }
-  };
-
-  const logout = async (api: SesamyAPI) => {
-    loading = true;
-    try {
-      await api.auth.logout();
-      loggedIn = false;
-    } catch (error) {
-      console.error('Logout failed:', error);
-    }
-  };
-
-  const checkLoggedIn = async (api: SesamyAPI) => {
-    try {
-      loggedIn = await api.auth.isAuthenticated();
-      if (loggedIn) {
-        const user = await api.auth.getUser();
-        userAvatar = user?.picture || '';
-      }
-    } catch (error) {
-      console.error('Error checking login status:', error);
-    }
-  };
 </script>
 
 <Base let:api let:t>

--- a/packages/lib/src/store.svelte.ts
+++ b/packages/lib/src/store.svelte.ts
@@ -1,0 +1,11 @@
+const loggingIn = $state(false);
+const loggingOut = $state(false);
+const isLoggedIn = $state(false);
+const user = $state();
+
+export default {
+  loggingIn,
+  loggingOut,
+  isLoggedIn,
+  user
+};

--- a/packages/lib/src/utils/authentication.ts
+++ b/packages/lib/src/utils/authentication.ts
@@ -1,0 +1,35 @@
+import type { SesamyAPI } from '@sesamy/sesamy-js';
+import store from '../store';
+
+let { loggingIn, loggingOut, isLoggedIn, user } = store;
+
+export const login = async (api: SesamyAPI) => {
+  loggingIn = true;
+  try {
+    await api.auth.loginWithRedirect();
+  } catch (error) {
+    loggingIn = false;
+    console.error('Login failed:', error);
+  }
+};
+
+export const logout = async (api: SesamyAPI) => {
+  loggingOut = true;
+  try {
+    await api.auth.logout();
+    isLoggedIn = false;
+  } catch (error) {
+    console.error('Logout failed:', error);
+  }
+};
+
+export const checkLoggedIn = async (api: SesamyAPI) => {
+  try {
+    isLoggedIn = await api.auth.isAuthenticated();
+    if (isLoggedIn) {
+      user = await api.auth.getUser();
+    }
+  } catch (error) {
+    console.error('Error checking login status:', error);
+  }
+};


### PR DESCRIPTION
This currently produces error:
![image](https://github.com/user-attachments/assets/e6b402e4-24ee-4a9b-8e8c-b74774265be0)

Here's another user with the same thing:
https://www.reddit.com/r/sveltejs/comments/1f7ieaz/cant_use_with_runes_in_sveltets_files_svelte_5/

The goal of this refactor is to be able to use the helper functions within `authentication.ts` with ease - rather than copy pasting auth-code all over.