### PR TITLE
fix: correct sesamy-js type import

### DIFF
--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -1,7 +1,7 @@
 <svelte:options customElement={{ tag: 'sesamy-content-container-beta', shadow: 'open' }} />
 
 <script lang="ts">
-  import { type SesamyAPI } from '@sesamy/sesamy-js';
+  import type { SesamyAPI } from '@sesamy/sesamy-js';
   import Base from './Base.svelte';
   import type { ContentContainerProps } from './types';
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated import statement for `SesamyAPI` to use type-only import syntax
  - No functional changes to the code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->