### PR TITLE
chore: dont run pw on push & use buildjet

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,10 +10,6 @@ jobs:
     steps:
       - name: Checkout ref
         uses: actions/checkout@v4
-      - name: Setup node
-        uses: buildjet/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,12 +7,15 @@ jobs:
     timeout-minutes: 60
     runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout ref
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: buildjet/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: '.nvmrc'
+          cache: yarn
       - name: Install dependencies
-        run: npm install -g yarn && yarn
+        run: yarn
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
       - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,11 +9,21 @@ jobs:
     steps:
       - name: Checkout ref
         uses: actions/checkout@v4
+      - name: Get yarn cache directory
+        id: yarn-cache-dir
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      - uses: buildjet/cache@v4
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Setup node
         uses: buildjet/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
+          cache: yarn-cache
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,21 +9,11 @@ jobs:
     steps:
       - name: Checkout ref
         uses: actions/checkout@v4
-      - name: Get yarn cache directory
-        id: yarn-cache-dir
-        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: buildjet/cache@v4
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
       - name: Setup node
         uses: buildjet/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn-cache
+          cache: yarn
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     timeout-minutes: 60
     runs-on: buildjet-8vcpu-ubuntu-2204
+    container: mcr.microsoft.com/playwright:v1.49.1-noble
     steps:
       - name: Checkout ref
         uses: actions/checkout@v4
@@ -13,7 +14,6 @@ jobs:
         uses: buildjet/setup-node@v4
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,27 +1,25 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, dev ]
   pull_request:
-    branches: [ main, dev ]
+    branches: [main, dev]
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
-      with:
-        node-version: lts/*
-    - name: Install dependencies
-      run: npm install -g yarn && yarn
-    - name: Install Playwright Browsers
-      run: yarn playwright install --with-deps
-    - name: Run Playwright tests
-      run: yarn test
-    - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g yarn && yarn
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+      - name: Run Playwright tests
+        run: yarn test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for Playwright tests.
	- Modified test environment settings to use a specific build environment.
	- Standardized workflow file formatting.
	- Simplified Node.js setup for running Yarn.
	- Introduced a specific Playwright Docker image for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->