### PR TITLE
fix: darkmode only when background enabled

### DIFF
--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -131,7 +131,7 @@
   }
 
   const paywallBgColor = styling?.backgroundColor || '#FFFFFF';
-  const darkMode = hexToHsl(paywallBgColor)[2] < 50;
+  const darkMode = styling?.showBackground && hexToHsl(paywallBgColor)[2] < 50;
   const paywallTextColor = darkMode ? '#FFFFFF' : '#000000';
 
   let sesamyPaywallDesignTokens = `


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the theme display logic so that dark mode is activated only when background styling is enabled. This change helps maintain consistent text contrast and improves the visual presentation on paywall pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->