### PR TITLE
fix: make single purchase not redirect to article

### DIFF
--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -115,6 +115,7 @@
     }
   };
 
+  // TODO: We are calling this with a single purchase today..
   const selectProduct = (option: PaywallSubscription) => {
     error = '';
     // TODO: decide if we should remove "features" from shallow paywall. And if so, if we should add it to singlePurchase.
@@ -222,7 +223,6 @@
 
               {#if !horizontal && singlePurchase?.enabled && singlePurchasePrice && articleUrl}
                 <SinglePurchase
-                  {api}
                   {singlePurchase}
                   {currency}
                   {singlePurchasePrice}

--- a/packages/lib/src/components/paywall/Selection.svelte
+++ b/packages/lib/src/components/paywall/Selection.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import Row from '../Row.svelte';
   import { twMerge } from 'tailwind-merge';
 
   type Props = {

--- a/packages/lib/src/components/paywall/SinglePurchase.svelte
+++ b/packages/lib/src/components/paywall/SinglePurchase.svelte
@@ -5,10 +5,8 @@
   import SelectionGroup from './SelectionGroup.svelte';
   import type { PaywallSinglePurchase } from 'src/types/Paywall';
   import type { PaywallProps } from 'src/types';
-  import type { SesamyAPI } from '@sesamy/sesamy-js';
 
   type Props = {
-    api: SesamyAPI;
     t: TranslationFunction;
     singlePurchase: PaywallSinglePurchase;
     selectProduct: Function;
@@ -19,7 +17,6 @@
 
   const props: Props = $props();
   let {
-    api,
     singlePurchase,
     selectProduct,
     hasSubscriptions,
@@ -30,7 +27,7 @@
   let { title, description } = singlePurchase;
 
   const completeAndSelect = () => {
-    selectProduct({ ...singlePurchase, price: singlePurchasePrice, url: articleUrl });
+    selectProduct({ ...singlePurchase, price: singlePurchasePrice });
   };
 
   if (articleUrl && !hasSubscriptions) {


### PR DESCRIPTION
By setting the articleUrl to the url when selecting the article we cause the continue button to redirect to the article instead of showing the next step of the paywall. At least that's my understanding :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the purchase workflow, streamlining the process for single-purchase selections.
  - Updated paywall component interactions to enhance efficiency and clarity in the purchase experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->