### PR TITLE
fix: actually send name and phonenr to checkout

### DIFF
--- a/packages/lib/src/components/paywall/PayNowForm.svelte
+++ b/packages/lib/src/components/paywall/PayNowForm.svelte
@@ -139,7 +139,10 @@
           method: isWallet ? 'CARD' : paymentMethod.method
         },
         country,
-        email
+        email,
+        phoneNumber: phoneNumber || undefined,
+        givenName: firstName || undefined,
+        familyName: lastName || undefined
       });
 
       goToCheckout(checkout, paymentMethod);


### PR DESCRIPTION
I just realized we have the name and phone number fields in the paywall, but we are currently not sending the data to checkout 😓 fix here

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checkout now supports capturing phone number, given name, and family name in addition to existing details for a smoother, more personalized payment experience.

* **Bug Fixes**
  * Prevents submitting empty personal information fields, reducing validation issues during checkout.

* **Chores**
  * Ensures only provided contact details are sent, with no changes to payment method selection or overall checkout flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->