### PR TITLE
fix: html parse single purchase description

### DIFF
--- a/packages/lib/src/components/paywall/SinglePurchase.svelte
+++ b/packages/lib/src/components/paywall/SinglePurchase.svelte
@@ -47,7 +47,7 @@
       <Column left>
         <div class="text-base font-bold leading-tight">{title}</div>
         <div class="text-sm">
-          {description}
+          {@html description}
         </div>
       </Column>
       <div class="text-base font-bold">{singlePurchasePrice} {currency}</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Paywall Single Purchase descriptions now support rich text/HTML, enabling formatted content such as links, lists, and emphasis.
  - Enhances readability and presentation of purchase details without altering existing behavior.

- Chores
  - No public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->