### PR TITLE
chore: migrate BuildJet runners and update GitHub Actions

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   playwright-cron:
     timeout-minutes: 30
-    runs-on: [self-hosted, linux, x64, buildjet-8vcpu-ubuntu-2204]
+    runs-on: ubuntu-latest-8-cores
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble@sha256:70e367e0cbf60340a5b5fd562f6247a34eb3196efab9f88a3dd56482d9fe09d2
       options: --ipc=host
@@ -19,19 +19,19 @@ jobs:
 
     steps:
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: yarn
       - name: Run Playwright tests
         run: yarn test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
           if-no-files-found: ignore
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: playwright-traces
@@ -40,7 +40,7 @@ jobs:
           if-no-files-found: ignore
       - name: Report failed test
         if: failure()
-        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
           url: ${{ secrets.SLACK_HOOK_TEST_RESULTS }}
           method: 'POST'
@@ -52,7 +52,7 @@ jobs:
             }
       - name: Report successful test
         if: success()
-        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
           url: ${{ secrets.SLACK_HOOK_TEST_RESULTS }}
           method: 'POST'

--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   playwright-cron:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble@sha256:70e367e0cbf60340a5b5fd562f6247a34eb3196efab9f88a3dd56482d9fe09d2
       options: --ipc=host

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,18 +5,18 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-8-cores
     container: mcr.microsoft.com/playwright:v1.49.1-noble
     steps:
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.49.1-noble
     steps:
       - name: Checkout ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary
- **BuildJet runner migration**: Replace `buildjet-8vcpu-ubuntu-2204` with `ubuntu-latest-8-cores` in Playwright workflows (BuildJet shuts down March 31, 2026)
- **Action version updates**: Pin all actions to latest versions with SHA references — `actions/checkout` v4→v6.0.2, `actions/setup-node` v4→v6.3.0, `actions/upload-artifact` v4→v7.0.0, `fjogeleit/http-request-action` v1→v2.0.0

## Test plan
- [ ] Verify release workflow runs successfully on `main`
- [ ] Verify Playwright tests pass on PR with `ubuntu-latest-8-cores` runner
- [ ] Monitor first cron Playwright run after merge (especially `http-request-action` v2 Slack notifications)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI/CD runner environments to a common, up-to-date Linux image.
  * Pinned workflow action versions across automation pipelines to improve build reproducibility, stability, and predictability of releases and scheduled tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->