### PR TITLE
fix(content-container): wait for DOMContentLoaded before extracting slot content, preserve script attributes

### DIFF
--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -14,17 +14,30 @@
 
   // Store the content slot element in memory
   let storedContentElement: Element | null = null;
+  // Resolves once storedContentElement has been populated (or confirmed absent)
+  let contentReady: Promise<void> = Promise.resolve();
 
   function extractAndStoreContent() {
     const host = $host();
     if (!host || storedContentElement) return;
 
-    const contentSlot = host.querySelector('[slot="content"]');
-    if (contentSlot) {
-      // Clone and store the content
-      storedContentElement = contentSlot.cloneNode(true) as Element;
-      // Remove from DOM
-      contentSlot.remove();
+    const doExtract = () => {
+      const contentSlot = host.querySelector('[slot="content"]');
+      if (contentSlot) {
+        // Clone and store the content
+        storedContentElement = contentSlot.cloneNode(true) as Element;
+        // Remove from DOM
+        contentSlot.remove();
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      // DOM still being parsed — slot children may not be fully appended yet
+      contentReady = new Promise<void>((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => { doExtract(); resolve(); }, { once: true });
+      });
+    } else {
+      doExtract();
     }
   }
 
@@ -81,16 +94,18 @@
 
     // Handle scripts
     const scripts = lockedContentNode.querySelectorAll('script');
-    const scriptContents: string[] = [];
+    const inlineScripts: HTMLScriptElement[] = [];
 
     scripts.forEach((script) => {
       try {
+        const newScript = document.createElement('script');
+        // Preserve all attributes (type, async, defer, crossorigin, etc.)
+        Array.from(script.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
         if (script.src) {
-          const newScript = document.createElement('script');
-          newScript.src = script.src;
           document.head.appendChild(newScript);
         } else {
-          scriptContents.push(script.textContent || '');
+          newScript.textContent = script.textContent;
+          inlineScripts.push(newScript);
         }
         script.parentNode?.removeChild(script);
       } catch (err) {
@@ -102,14 +117,14 @@
     host.parentElement?.insertBefore(lockedContentNode, host);
 
     // Execute inline scripts
-    scriptContents.forEach((code) => {
+    inlineScripts.forEach((script) => {
       try {
-        const script = document.createElement('script');
-        script.textContent = code;
         document.head.appendChild(script);
+        // Only remove synchronously for non-module scripts; modules execute async
+        // and removing after append does not interrupt execution either way
         document.head.removeChild(script);
       } catch (err) {
-        console.error('Failed to execute inline script:', err, code);
+        console.error('Failed to execute inline script:', err, script);
       }
     });
   }
@@ -117,6 +132,7 @@
   async function fetchContent(api: SesamyAPI): Promise<string> {
     switch (lockMode) {
       case 'encode':
+        await contentReady;
         const base64 = storedContentElement?.innerHTML || '';
         // Convert base64 to UTF-8 string
         try {
@@ -132,6 +148,7 @@
       case 'signedUrl':
         return api.content.unlock($host().parentElement!, lockedContentSelector);
       case 'embed':
+        await contentReady;
         return storedContentElement?.innerHTML || '';
       default:
         console.error('Invalid lock mode');

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -34,7 +34,14 @@
     if (document.readyState === 'loading') {
       // DOM still being parsed — slot children may not be fully appended yet
       contentReady = new Promise<void>((resolve) => {
-        document.addEventListener('DOMContentLoaded', () => { doExtract(); resolve(); }, { once: true });
+        document.addEventListener(
+          'DOMContentLoaded',
+          () => {
+            doExtract();
+            resolve();
+          },
+          { once: true }
+        );
       });
     } else {
       doExtract();
@@ -100,7 +107,9 @@
       try {
         const newScript = document.createElement('script');
         // Preserve all attributes (type, async, defer, crossorigin, etc.)
-        Array.from(script.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+        Array.from(script.attributes).forEach((attr) =>
+          newScript.setAttribute(attr.name, attr.value)
+        );
         if (script.src) {
           document.head.appendChild(newScript);
         } else {

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -120,9 +120,12 @@
     inlineScripts.forEach((script) => {
       try {
         document.head.appendChild(script);
-        // Only remove synchronously for non-module scripts; modules execute async
-        // and removing after append does not interrupt execution either way
-        document.head.removeChild(script);
+        // Module scripts execute asynchronously; don't remove them so the browser
+        // can finish loading imports. Non-module scripts execute synchronously on
+        // append so they can be removed immediately after.
+        if (script.type !== 'module') {
+          document.head.removeChild(script);
+        }
       } catch (err) {
         console.error('Failed to execute inline script:', err, script);
       }

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -14,44 +14,19 @@
 
   // Store the content slot element in memory
   let storedContentElement: Element | null = null;
-  // Resolves once storedContentElement has been populated (or confirmed absent)
-  let contentReady: Promise<void> = Promise.resolve();
 
   function extractAndStoreContent() {
     const host = $host();
     if (!host || storedContentElement) return;
 
-    const doExtract = () => {
-      const contentSlot = host.querySelector('[slot="content"]');
-      if (contentSlot) {
-        // Clone and store the content
-        storedContentElement = contentSlot.cloneNode(true) as Element;
-        // Remove from DOM
-        contentSlot.remove();
-      }
-    };
-
-    if (document.readyState === 'loading') {
-      // DOM still being parsed — slot children may not be fully appended yet
-      contentReady = new Promise<void>((resolve) => {
-        document.addEventListener(
-          'DOMContentLoaded',
-          () => {
-            doExtract();
-            resolve();
-          },
-          { once: true }
-        );
-      });
-    } else {
-      doExtract();
+    const contentSlot = host.querySelector('[slot="content"]');
+    if (contentSlot) {
+      // Clone and store the content
+      storedContentElement = contentSlot.cloneNode(true) as Element;
+      // Remove from DOM
+      contentSlot.remove();
     }
   }
-
-  // Extract content on component initialization
-  $effect(() => {
-    extractAndStoreContent();
-  });
 
   async function checkAccess(api: SesamyAPI) {
     const content = api.content.get($host());
@@ -144,7 +119,6 @@
   async function fetchContent(api: SesamyAPI): Promise<string> {
     switch (lockMode) {
       case 'encode':
-        await contentReady;
         const base64 = storedContentElement?.innerHTML || '';
         // Convert base64 to UTF-8 string
         try {
@@ -160,7 +134,6 @@
       case 'signedUrl':
         return api.content.unlock($host().parentElement!, lockedContentSelector);
       case 'embed':
-        await contentReady;
         return storedContentElement?.innerHTML || '';
       default:
         console.error('Invalid lock mode');
@@ -170,6 +143,9 @@
 
   async function unlockAndRenderContent(api: SesamyAPI) {
     try {
+      // sesamyJsReady (which resolves readyPromise) only fires after DOMContentLoaded,
+      // so the DOM is fully parsed by the time we reach here.
+      extractAndStoreContent();
       const contentHtml = await fetchContent(api);
       await injectContent(contentHtml);
 


### PR DESCRIPTION
## Summary

- **DOM timing fix**: When the sesamy bundle is cached, it can execute as an `async type="module"` script before the browser finishes parsing the body. `extractAndStoreContent` was cloning `[slot="content"]` while its children were only partially appended — resulting in empty or incomplete injected content (e.g. only an HTML comment like `<!-- placeholder(#1) -->`). Fixed by checking `document.readyState === 'loading'` and deferring extraction to `DOMContentLoaded`, with a `contentReady` promise that `fetchContent` awaits for `embed`/`encode` modes.
- **Module script fix**: `injectContent` was dropping all script attributes (including `type="module"`) when re-creating script elements. Inline module scripts with `import` statements were throwing "Cannot use import statement outside a module". Fixed by copying all attributes from the original script element to the new one.

## Test plan

- [ ] Verify content injection works on first load (bundle not cached)
- [ ] Verify content injection works on subsequent loads (bundle served from cache, timing issue previously triggered)
- [ ] Verify inline `<script type="module">` with `import` statements executes correctly after unlock
- [ ] Verify external scripts and other script attributes (`async`, `defer`, `crossorigin`) are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted content extraction timing to run during the unlock/render flow, avoiding premature reads.
  * Reworked inline script handling to recreate script elements, preserve original attributes, and manage execution order more reliably.
  * Improved error reporting to surface failing script elements for easier troubleshooting.

* **Bug Fixes**
  * Prevents race conditions when encoding or embedding content by ensuring extraction occurs at the correct time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->