### PR TITLE
Release

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   playwright-cron:
     timeout-minutes: 30
-    runs-on: [self-hosted, linux, x64, buildjet-8vcpu-ubuntu-2204]
+    runs-on: ubuntu-latest-8-cores
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble@sha256:70e367e0cbf60340a5b5fd562f6247a34eb3196efab9f88a3dd56482d9fe09d2
       options: --ipc=host
@@ -19,19 +19,19 @@ jobs:
 
     steps:
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: yarn
       - name: Run Playwright tests
         run: yarn test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
           if-no-files-found: ignore
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: playwright-traces
@@ -40,7 +40,7 @@ jobs:
           if-no-files-found: ignore
       - name: Report failed test
         if: failure()
-        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
           url: ${{ secrets.SLACK_HOOK_TEST_RESULTS }}
           method: 'POST'
@@ -52,7 +52,7 @@ jobs:
             }
       - name: Report successful test
         if: success()
-        uses: fjogeleit/http-request-action@44816be1eabb9c1122d8d775923f39bbe55c67a3 # v1
+        uses: fjogeleit/http-request-action@551353b829c3646756b2ec2b3694f819d7957495 # v2.0.0
         with:
           url: ${{ secrets.SLACK_HOOK_TEST_RESULTS }}
           method: 'POST'

--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   playwright-cron:
     timeout-minutes: 30
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.49.1-noble@sha256:70e367e0cbf60340a5b5fd562f6247a34eb3196efab9f88a3dd56482d9fe09d2
       options: --ipc=host

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,18 +5,18 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: ubuntu-latest-8-cores
     container: mcr.microsoft.com/playwright:v1.49.1-noble
     steps:
       - name: Checkout ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers
         run: yarn playwright install --with-deps
       - name: Run Playwright tests
         run: yarn test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     container: mcr.microsoft.com/playwright:v1.49.1-noble
     steps:
       - name: Checkout ref

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -14,17 +14,30 @@
 
   // Store the content slot element in memory
   let storedContentElement: Element | null = null;
+  // Resolves once storedContentElement has been populated (or confirmed absent)
+  let contentReady: Promise<void> = Promise.resolve();
 
   function extractAndStoreContent() {
     const host = $host();
     if (!host || storedContentElement) return;
 
-    const contentSlot = host.querySelector('[slot="content"]');
-    if (contentSlot) {
-      // Clone and store the content
-      storedContentElement = contentSlot.cloneNode(true) as Element;
-      // Remove from DOM
-      contentSlot.remove();
+    const doExtract = () => {
+      const contentSlot = host.querySelector('[slot="content"]');
+      if (contentSlot) {
+        // Clone and store the content
+        storedContentElement = contentSlot.cloneNode(true) as Element;
+        // Remove from DOM
+        contentSlot.remove();
+      }
+    };
+
+    if (document.readyState === 'loading') {
+      // DOM still being parsed — slot children may not be fully appended yet
+      contentReady = new Promise<void>((resolve) => {
+        document.addEventListener('DOMContentLoaded', () => { doExtract(); resolve(); }, { once: true });
+      });
+    } else {
+      doExtract();
     }
   }
 
@@ -81,16 +94,18 @@
 
     // Handle scripts
     const scripts = lockedContentNode.querySelectorAll('script');
-    const scriptContents: string[] = [];
+    const inlineScripts: HTMLScriptElement[] = [];
 
     scripts.forEach((script) => {
       try {
+        const newScript = document.createElement('script');
+        // Preserve all attributes (type, async, defer, crossorigin, etc.)
+        Array.from(script.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
         if (script.src) {
-          const newScript = document.createElement('script');
-          newScript.src = script.src;
           document.head.appendChild(newScript);
         } else {
-          scriptContents.push(script.textContent || '');
+          newScript.textContent = script.textContent;
+          inlineScripts.push(newScript);
         }
         script.parentNode?.removeChild(script);
       } catch (err) {
@@ -102,14 +117,14 @@
     host.parentElement?.insertBefore(lockedContentNode, host);
 
     // Execute inline scripts
-    scriptContents.forEach((code) => {
+    inlineScripts.forEach((script) => {
       try {
-        const script = document.createElement('script');
-        script.textContent = code;
         document.head.appendChild(script);
+        // Only remove synchronously for non-module scripts; modules execute async
+        // and removing after append does not interrupt execution either way
         document.head.removeChild(script);
       } catch (err) {
-        console.error('Failed to execute inline script:', err, code);
+        console.error('Failed to execute inline script:', err, script);
       }
     });
   }
@@ -117,6 +132,7 @@
   async function fetchContent(api: SesamyAPI): Promise<string> {
     switch (lockMode) {
       case 'encode':
+        await contentReady;
         const base64 = storedContentElement?.innerHTML || '';
         // Convert base64 to UTF-8 string
         try {
@@ -132,6 +148,7 @@
       case 'signedUrl':
         return api.content.unlock($host().parentElement!, lockedContentSelector);
       case 'embed':
+        await contentReady;
         return storedContentElement?.innerHTML || '';
       default:
         console.error('Invalid lock mode');

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -34,7 +34,14 @@
     if (document.readyState === 'loading') {
       // DOM still being parsed — slot children may not be fully appended yet
       contentReady = new Promise<void>((resolve) => {
-        document.addEventListener('DOMContentLoaded', () => { doExtract(); resolve(); }, { once: true });
+        document.addEventListener(
+          'DOMContentLoaded',
+          () => {
+            doExtract();
+            resolve();
+          },
+          { once: true }
+        );
       });
     } else {
       doExtract();
@@ -100,7 +107,9 @@
       try {
         const newScript = document.createElement('script');
         // Preserve all attributes (type, async, defer, crossorigin, etc.)
-        Array.from(script.attributes).forEach((attr) => newScript.setAttribute(attr.name, attr.value));
+        Array.from(script.attributes).forEach((attr) =>
+          newScript.setAttribute(attr.name, attr.value)
+        );
         if (script.src) {
           document.head.appendChild(newScript);
         } else {

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -120,9 +120,12 @@
     inlineScripts.forEach((script) => {
       try {
         document.head.appendChild(script);
-        // Only remove synchronously for non-module scripts; modules execute async
-        // and removing after append does not interrupt execution either way
-        document.head.removeChild(script);
+        // Module scripts execute asynchronously; don't remove them so the browser
+        // can finish loading imports. Non-module scripts execute synchronously on
+        // append so they can be removed immediately after.
+        if (script.type !== 'module') {
+          document.head.removeChild(script);
+        }
       } catch (err) {
         console.error('Failed to execute inline script:', err, script);
       }

--- a/packages/lib/src/ContentContainer.wc.svelte
+++ b/packages/lib/src/ContentContainer.wc.svelte
@@ -14,44 +14,19 @@
 
   // Store the content slot element in memory
   let storedContentElement: Element | null = null;
-  // Resolves once storedContentElement has been populated (or confirmed absent)
-  let contentReady: Promise<void> = Promise.resolve();
 
   function extractAndStoreContent() {
     const host = $host();
     if (!host || storedContentElement) return;
 
-    const doExtract = () => {
-      const contentSlot = host.querySelector('[slot="content"]');
-      if (contentSlot) {
-        // Clone and store the content
-        storedContentElement = contentSlot.cloneNode(true) as Element;
-        // Remove from DOM
-        contentSlot.remove();
-      }
-    };
-
-    if (document.readyState === 'loading') {
-      // DOM still being parsed — slot children may not be fully appended yet
-      contentReady = new Promise<void>((resolve) => {
-        document.addEventListener(
-          'DOMContentLoaded',
-          () => {
-            doExtract();
-            resolve();
-          },
-          { once: true }
-        );
-      });
-    } else {
-      doExtract();
+    const contentSlot = host.querySelector('[slot="content"]');
+    if (contentSlot) {
+      // Clone and store the content
+      storedContentElement = contentSlot.cloneNode(true) as Element;
+      // Remove from DOM
+      contentSlot.remove();
     }
   }
-
-  // Extract content on component initialization
-  $effect(() => {
-    extractAndStoreContent();
-  });
 
   async function checkAccess(api: SesamyAPI) {
     const content = api.content.get($host());
@@ -144,7 +119,6 @@
   async function fetchContent(api: SesamyAPI): Promise<string> {
     switch (lockMode) {
       case 'encode':
-        await contentReady;
         const base64 = storedContentElement?.innerHTML || '';
         // Convert base64 to UTF-8 string
         try {
@@ -160,7 +134,6 @@
       case 'signedUrl':
         return api.content.unlock($host().parentElement!, lockedContentSelector);
       case 'embed':
-        await contentReady;
         return storedContentElement?.innerHTML || '';
       default:
         console.error('Invalid lock mode');
@@ -170,6 +143,9 @@
 
   async function unlockAndRenderContent(api: SesamyAPI) {
     try {
+      // sesamyJsReady (which resolves readyPromise) only fires after DOMContentLoaded,
+      // so the DOM is fully parsed by the time we reach here.
+      extractAndStoreContent();
       const contentHtml = await fetchContent(api);
       await injectContent(contentHtml);
 


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows and refines script handling in the `ContentContainer.wc.svelte` component. The workflow changes mainly upgrade action versions, improve security by pinning actions to specific commit SHAs, and standardize runner environments. The Svelte component changes focus on more robust and accurate script extraction and execution when injecting content.

**GitHub Actions workflow updates:**

* Upgraded all critical actions in `.github/workflows/playwright-cron.yml`, `.github/workflows/playwright.yml`, and `.github/workflows/release.yml` to use pinned commit SHAs for better security and reliability. This includes `actions/checkout`, `actions/upload-artifact`, `actions/setup-node`, and `fjogeleit/http-request-action`. [[1]](diffhunk://#diff-0674e6d5e0c83515434e749f11112886195666b4766d4442a4ab39e035722d7fL22-R34) [[2]](diffhunk://#diff-0674e6d5e0c83515434e749f11112886195666b4766d4442a4ab39e035722d7fL43-R43) [[3]](diffhunk://#diff-0674e6d5e0c83515434e749f11112886195666b4766d4442a4ab39e035722d7fL55-R55) [[4]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L8-R19) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-R13)
* Standardized workflow runners to use `ubuntu-latest` instead of custom or self-hosted runners, ensuring more predictable and maintainable CI environments. [[1]](diffhunk://#diff-0674e6d5e0c83515434e749f11112886195666b4766d4442a4ab39e035722d7fL13-R13) [[2]](diffhunk://#diff-7afcd2d8f7b49bda74843f209eefb7b2da45f7e7803bf2e4bd636699b76aa2d3L8-R19)

**`ContentContainer.wc.svelte` improvements:**

* Improved script extraction and execution logic: now all script attributes are preserved, and inline scripts are handled more robustly. Module scripts are left in the DOM to allow asynchronous execution, while non-module scripts are removed after execution. [[1]](diffhunk://#diff-7381e6113e51c464144105d005ffe504a7dc0cd1930cc7d225b5d5570f1c944fL84-R92) [[2]](diffhunk://#diff-7381e6113e51c464144105d005ffe504a7dc0cd1930cc7d225b5d5570f1c944fL105-R114)
* Moved the call to `extractAndStoreContent()` to the start of the `unlockAndRenderContent` function, ensuring content extraction only happens after the DOM is fully parsed and ready.
* Removed the `$effect` block that previously triggered content extraction on component initialization, as this is now handled more deliberately in the unlock flow.