### PR TITLE
fix(paywall): only set business checkout flag when preferBusiness is true

### DIFF
--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -131,7 +131,7 @@
       });
 
       if (horizontal || selectedProduct.preferBusiness) {
-        goToCheckout(createdCheckout, undefined, true);
+        goToCheckout(createdCheckout, undefined, selectedProduct.preferBusiness);
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixed `goToCheckout` call that hardcoded the `business` parameter to `true` for both horizontal layouts and `preferBusiness` products
- Now correctly passes `selectedProduct.preferBusiness` so horizontal-only checkouts don't incorrectly trigger business checkout

## Test plan
- [x] Verify horizontal paywall without `preferBusiness` does not redirect to business checkout
- [x] Verify product with `preferBusiness: true` still correctly triggers business checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)