### PR TITLE
feat: show SWISH_DIRECT in paywall payment methods

### DIFF
--- a/packages/lib/src/components/PaymentMethodLogo.svelte
+++ b/packages/lib/src/components/PaymentMethodLogo.svelte
@@ -9,7 +9,7 @@
   $: methodLower = (method ?? '').toLowerCase();
 </script>
 
-{#if methodLower === 'swish'}
+{#if methodLower === 'swish' || methodLower === 'swish_direct'}
   <svg xmlns="http://www.w3.org/2000/svg" {width} {height} viewBox="0 0 578 176">
     <defs>
       <linearGradient

--- a/packages/lib/src/components/paywall/PayNowForm.svelte
+++ b/packages/lib/src/components/paywall/PayNowForm.svelte
@@ -251,6 +251,16 @@
     }
   }
 
+  // Remove SWISH if both SWISH_DIRECT and SWISH are present
+  const hasSwishDirect = paymentMethods.some((pm) => pm.method === 'SWISH_DIRECT');
+  const hasSwish = paymentMethods.some((pm) => pm.method === 'SWISH');
+  if (hasSwishDirect && hasSwish) {
+    const swishIndex = paymentMethods.findIndex((pm) => pm.method === 'SWISH');
+    if (swishIndex !== -1) {
+      paymentMethods.splice(swishIndex, 1);
+    }
+  }
+
   // Filter and sort payment methods according to PAYMENT_METHODS_SORT_ORDER
   const sortedPaymentMethods = PAYMENT_METHODS_SORT_ORDER.map((method) =>
     paymentMethods.find((pm) => pm.method === method)

--- a/packages/lib/src/constants/payment-methods.ts
+++ b/packages/lib/src/constants/payment-methods.ts
@@ -4,6 +4,7 @@ export const PAYMENT_METHODS_SORT_ORDER = [
   'KLARNA_PRIVATE',
   'STRIPE_KLARNA',
   'VIPPS',
+  'SWISH_DIRECT',
   'SWISH',
   'CARD'
 ];


### PR DESCRIPTION
## Summary
- Adds `SWISH_DIRECT` to `PAYMENT_METHODS_SORT_ORDER` so it can render in the paywall payment method list.
- Reuses the existing Swish SVG in `PaymentMethodLogo` for both `swish` and `swish_direct`.
- When both `SWISH_DIRECT` and `SWISH` are returned in `availablePaymentMethods`, hides `SWISH` (mirrors the existing `STRIPE_KLARNA` / `KLARNA_PRIVATE` dedup pattern in `PayNowForm`).

Closes [SES-214](https://linear.app/sesamy-ab/issue/SES-214/show-swish-direct-in-the-paywall)

## Test plan
- [ ] Paywall with only `SWISH` available → Swish option renders as today.
- [ ] Paywall with only `SWISH_DIRECT` available → Swish logo renders, selecting it routes through the SWISH_DIRECT provider.
- [ ] Paywall with both `SWISH_DIRECT` and `SWISH` available → only one Swish option appears, and it is `SWISH_DIRECT`.
- [ ] Sort order still places Swish before Card and after Vipps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swish Direct as a new and distinct payment method option, providing customers with an enhanced selection of payment alternatives during the checkout process.

* **Bug Fixes**
  * Improved the payment method selection logic to prevent duplicate or conflicting payment options when both the standard Swish method and the new Swish Direct variant are simultaneously available for customer selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sesamyab/sesamy-components/pull/333)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->