### PR TITLE
refactor: reorder payment methods sort order

### DIFF
--- a/packages/lib/src/constants/payment-methods.ts
+++ b/packages/lib/src/constants/payment-methods.ts
@@ -1,10 +1,10 @@
 export const PAYMENT_METHODS_SORT_ORDER = [
-  'APPLE-PAY',
-  'GOOGLE-PAY',
+  'VIPPS',
   'KLARNA_PRIVATE',
   'STRIPE_KLARNA',
-  'VIPPS',
   'SWISH_DIRECT',
   'SWISH',
+  'APPLE-PAY',
+  'GOOGLE-PAY',
   'CARD'
 ];


### PR DESCRIPTION
## Summary
- Reorder `PAYMENT_METHODS_SORT_ORDER` so regional/local methods (VIPPS, KLARNA_PRIVATE, STRIPE_KLARNA, SWISH_DIRECT, SWISH) appear before APPLE-PAY, GOOGLE-PAY, and CARD.

## Test plan
- [ ] Verify paywall renders payment methods in the new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered payment method display options. Vipps, Klarna Private, Stripe Klarna, Swish Direct, and Swish now appear earlier in the payment selection flow. Apple Pay and Google Pay appear later, with card payment remaining as the final option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sesamyab/sesamy-components/pull/337?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->