### PR TITLE
chore: run playwright cron nightly at 02:00 UTC

### DIFF
--- a/.github/workflows/playwright-cron.yml
+++ b/.github/workflows/playwright-cron.yml
@@ -1,7 +1,7 @@
 name: Playwright Tests - Cron runner
 on:
   schedule:
-    - cron: '0 5 * * 0-6'
+    - cron: '0 2 * * *' # every day at 02:00 (UTC)
 
 permissions:
   contents: read # Required for actions/checkout


### PR DESCRIPTION
## What

Move the Playwright cron schedule from `0 5 * * 0-6` to `0 2 * * *`.

## Why

The `0 5` (05:00 UTC) schedule was firing ~60–90 min late due to GitHub Actions' scheduled-workflow queue delay — top-of-the-hour, round-number slots are heavily contended ("high load times include the start of every hour"). Moving to **02:00 UTC** (off-peak) means even a worst-case queue delay still finishes before the workday starts. Also dropped the redundant `0-6` day-of-week range (identical to "every day").

> Actions cron runs in UTC and ignores DST, so the Swedish wall-clock time drifts ±1h between summer and winter regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test automation schedule to run daily instead of weekly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->