### PR TITLE
fix(paywall): attribute checkout to the paywall's own resolved article

### DIFF
--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -49,11 +49,21 @@
   let loading = $state(false);
   let error = $state('');
 
+  const contentArticle = api.content.get(host);
   const singlePurchasePrice = userProps?.['price']
     ? parsePrice(userProps['price'])
-    : api.content.get(host)?.price;
-  const articleUrl = userProps?.['item-src'] || api.content.get(host)?.url;
+    : contentArticle?.price;
+  const articleUrl = userProps?.['item-src'] || contentArticle?.url;
   const redirectUrl = userProps?.['redirect-url'] || window.location.href;
+
+  // URL to attribute the checkout to. Prefer an explicit `item-src` attribute,
+  // otherwise the URL of a content article resolved from a real ancestor
+  // element. When `content.get` falls back to the host itself (no article
+  // wrapper around the paywall) its `url` is just window.location.href — we skip
+  // that case and let sesamy-js resolve attribution instead of clobbering it.
+  const attributionItemSrc =
+    userProps?.['item-src'] ||
+    (contentArticle && contentArticle.element !== host ? contentArticle.url : undefined);
 
   let {
     subscriptions,
@@ -134,8 +144,10 @@
           utmCampaign: userProps?.['utm-campaign'],
           utmTerm: userProps?.['utm-term'],
           utmContent: userProps?.['utm-content'],
-          // Override the article attribution when the vendor sets `item-src` explicitly on the paywall.
-          ...(userProps?.['item-src'] ? { itemSrc: articleUrl } : {}),
+          // Attribute the checkout to this paywall's own article (explicit
+          // `item-src` or a resolved content article). Omitted when neither is
+          // available so sesamy-js's own attribution resolution stands.
+          ...(attributionItemSrc ? { itemSrc: attributionItemSrc } : {}),
           source: 'PAYWALL' as const,
           sourceId: paywall.id
         }

--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -56,15 +56,6 @@
   const articleUrl = userProps?.['item-src'] || contentArticle?.url;
   const redirectUrl = userProps?.['redirect-url'] || window.location.href;
 
-  // URL to attribute the checkout to. Prefer an explicit `item-src` attribute,
-  // otherwise the URL of a content article resolved from a real ancestor
-  // element. When `content.get` falls back to the host itself (no article
-  // wrapper around the paywall) its `url` is just window.location.href — we skip
-  // that case and let sesamy-js resolve attribution instead of clobbering it.
-  const attributionItemSrc =
-    userProps?.['item-src'] ||
-    (contentArticle && contentArticle.element !== host ? contentArticle.url : undefined);
-
   let {
     subscriptions,
     singlePurchase,
@@ -144,10 +135,10 @@
           utmCampaign: userProps?.['utm-campaign'],
           utmTerm: userProps?.['utm-term'],
           utmContent: userProps?.['utm-content'],
-          // Attribute the checkout to this paywall's own article (explicit
-          // `item-src` or a resolved content article). Omitted when neither is
-          // available so sesamy-js's own attribution resolution stands.
-          ...(attributionItemSrc ? { itemSrc: attributionItemSrc } : {}),
+          // Attribute the checkout to this paywall's article: the explicit
+          // `item-src` attribute, or the URL resolved from the paywall host
+          // (which itself falls back to the page URL in sesamy-js).
+          ...(articleUrl ? { itemSrc: articleUrl } : {}),
           source: 'PAYWALL' as const,
           sourceId: paywall.id
         }

--- a/packages/lib/src/components/paywall/Renderer.svelte
+++ b/packages/lib/src/components/paywall/Renderer.svelte
@@ -134,6 +134,8 @@
           utmCampaign: userProps?.['utm-campaign'],
           utmTerm: userProps?.['utm-term'],
           utmContent: userProps?.['utm-content'],
+          // Override the article attribution when the vendor sets `item-src` explicitly on the paywall.
+          ...(userProps?.['item-src'] ? { itemSrc: articleUrl } : {}),
           source: 'PAYWALL' as const,
           sourceId: paywall.id
         }


### PR DESCRIPTION
## Problem

When a checkout is created from a paywall, the `itemSrc` forwarded to checkout-api came from `sesamy-js`'s **page-global attribution**, computed **once at page init** from `content.list()[0]` and never refreshed. The paywall already knows its own article (`item-src` attribute, or host-scoped `api.content.get(host)`) and uses it for the access check — but never passed it into the checkout `attribution`, so the stale global always won.

On sites where the URL is mutated while scrolling (e.g. **AJAX Load More** infinite scroll, URL rewritten via `pushState`), this meant every checkout was attributed to the **landing** article instead of the one the reader actually purchased on.

## Change

`Renderer.svelte` now forwards the paywall's own article URL as `attribution.itemSrc`:

```js
const contentArticle = api.content.get(host);
const articleUrl = userProps?.['item-src'] || contentArticle?.url;
// ...
...(articleUrl ? { itemSrc: articleUrl } : {}),
```

`articleUrl` is the explicit `item-src` attribute, else the host-resolved article URL from `content.get(host)` — which in `sesamy-js` itself falls back to the page URL when no per-article value resolves. So `itemSrc` is always at least the page URL, and is the correct per-article URL whenever the paywall is wrapped in a real content article.

Because `api.checkouts.create` merges `{ ...globalAttribution, ...params.attribution }`, this value overrides the stale global.

## Resolution order for `itemSrc`

1. `item-src` attribute on `<sesamy-paywall>` (explicit)
2. host-resolved article URL — `content.get(host).url` (the per-article anchor, e.g. an infinite-scroll wrapper's data attribute)
3. page URL — `window.location.href` (the floor, applied inside `sesamy-js`)

## Rollout note

For a vendor to benefit on a mutating-URL page, their content config must expose a stable per-article URL that `content.get(host)` can resolve (point the `article` selector at the per-article wrapper and `url` at its data attribute). Ship this component change first, then update the vendor config.

## Testing

- `yarn run check` — no new errors (one pre-existing `payerEmail` type error from a stale local `@sesamy/sdk` type, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paywall checkout attribution by correctly resolving the transaction’s item source from the configured “item-src” when available, and using the resolved article URL when not.
  * Prevents incorrect attribution when the item source matches the host, helping downstream attribution resolve more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->