### PR TITLE
fix: avoid bare @sesamy/sesamy-js specifier in the built bundle

### DIFF
--- a/packages/lib/src/Login.wc.svelte
+++ b/packages/lib/src/Login.wc.svelte
@@ -2,7 +2,6 @@
 
 <script lang="ts">
   import type { SesamyAPI, Profile } from '@sesamy/sesamy-js';
-  import { Events } from '@sesamy/sesamy-js';
   import { onMount, onDestroy } from 'svelte';
   import Base from './Base.svelte';
   import type { LoginProps } from './types';
@@ -13,6 +12,7 @@
   import {
     dispatchSesamyEvent,
     authTransition,
+    SesamyJsEvent,
     type AuthState,
     type SesamyLoginSuccessDetail
   } from './events';
@@ -94,14 +94,14 @@
   };
 
   onMount(() => {
-    window.addEventListener(Events.AUTHENTICATED, onAuthenticatedEvent);
-    window.addEventListener(Events.LOGOUT, onLogoutEvent);
+    window.addEventListener(SesamyJsEvent.AUTHENTICATED, onAuthenticatedEvent);
+    window.addEventListener(SesamyJsEvent.LOGOUT, onLogoutEvent);
     window.addEventListener('pageshow', onPageShow);
     document.addEventListener('pointerdown', handleClickOutside);
   });
   onDestroy(() => {
-    window.removeEventListener(Events.AUTHENTICATED, onAuthenticatedEvent);
-    window.removeEventListener(Events.LOGOUT, onLogoutEvent);
+    window.removeEventListener(SesamyJsEvent.AUTHENTICATED, onAuthenticatedEvent);
+    window.removeEventListener(SesamyJsEvent.LOGOUT, onLogoutEvent);
     window.removeEventListener('pageshow', onPageShow);
     document.removeEventListener('pointerdown', handleClickOutside);
     if (resetTimer) {

--- a/packages/lib/src/events.ts
+++ b/packages/lib/src/events.ts
@@ -37,6 +37,19 @@ export interface SesamyContentUnlockedDetail {
   contentName: string;
 }
 
+// Global `window` events that @sesamy/sesamy-js dispatches and the components
+// listen for. These mirror sesamy-js's `Events` enum but are inlined here on
+// purpose: the library build externalizes @sesamy/sesamy-js, so importing the
+// enum as a runtime value leaves a bare `@sesamy/sesamy-js` specifier in the
+// output bundle. That fails to resolve when the bundle is loaded directly in a
+// browser via a plain module script (as the demo does), with:
+//   "Failed to resolve module specifier '@sesamy/sesamy-js'".
+// The values below are sesamy-js's stable public event names.
+export const SesamyJsEvent = {
+  AUTHENTICATED: 'sesamyJsAuthenticated',
+  LOGOUT: 'sesamyJsLogout'
+} as const;
+
 export const SesamyEventName = {
   LOGIN_SUCCESS: 'sesamy:login-success',
   LOGIN_ERROR: 'sesamy:login-error',


### PR DESCRIPTION
## Problem

The demo / Vercel preview fails to load with:

> Uncaught TypeError: Failed to resolve module specifier "@sesamy/sesamy-js". Relative references must start with either "/", "./", or "../".

This is **pre-existing on `dev`** (not introduced by any recent feature).

## Root cause

`Login.wc.svelte` imported the **`Events` enum** — a runtime value, not a type — from `@sesamy/sesamy-js`:

```ts
import { Events } from '@sesamy/sesamy-js';
// ...
window.addEventListener(Events.AUTHENTICATED, ...)
window.addEventListener(Events.LOGOUT, ...)
```

The library build (`vite.lib.config.ts`) **externalizes** `@sesamy/sesamy-js`, so that runtime import survives into `dist/lib/sesamy-components.es.js` as a bare:

```js
import { Events } from "@sesamy/sesamy-js";
```

The demo injects that built bundle as a plain module script (`<script type="module" src="/lib/sesamy-components.es.js">` via the `add-webcomponent` plugin). A browser can't resolve a bare specifier without an import map, so it throws. This was the **only** runtime import of `@sesamy/sesamy-js` in the library — everything else is `import type`, which is erased at build time.

## Fix

Inline the two window event names the component listens for as local constants in `events.ts` (`SesamyJsEvent.AUTHENTICATED = 'sesamyJsAuthenticated'`, `SesamyJsEvent.LOGOUT = 'sesamyJsLogout'`) instead of importing the enum. These are sesamy-js's stable public event names.

The built `es.js` is now **fully self-contained** (no external imports), so it loads directly in a browser — and the published library no longer requires an import map to be used as a raw module.

## Verification

Reproduced locally by building against the registry `@sesamy/sesamy-js` (the Vercel condition): before, `dist/lib/sesamy-components.es.js` contained the bare `import { Events } from "@sesamy/sesamy-js"`. After the fix, `grep "@sesamy/sesamy-js" dist/lib/sesamy-components.es.js` → 0 matches; the demo bundle has no bare import either. `yarn build` and `svelte-check` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication event handling so login and logout updates are handled more reliably.
  * Fixed global event listener cleanup to help prevent stale listeners after the component is unloaded.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->